### PR TITLE
chore: bump version from 0.1.1 to 0.3.0

### DIFF
--- a/custom_components/mylight_systems/const.py
+++ b/custom_components/mylight_systems/const.py
@@ -10,7 +10,7 @@ LOGGER: Logger = getLogger(__package__)
 NAME = "MyLight Systems"
 DOMAIN = "mylight_systems"
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
-VERSION = "0.1.1"
+VERSION = "0.3.0"
 ATTRIBUTION = "Data provided by https://www.mylight-systems.com/"
 SCAN_INTERVAL_IN_MINUTES = 15
 

--- a/custom_components/mylight_systems/manifest.json
+++ b/custom_components/mylight_systems/manifest.json
@@ -9,5 +9,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/acesyde/hassio_mylight_integration/issues",
-  "version": "0.1.1"
+  "version": "0.3.0"
 }

--- a/mise.lock
+++ b/mise.lock
@@ -8,6 +8,30 @@ backend = "aqua:rhysd/actionlint"
 version = "4.5.1"
 backend = "aqua:pre-commit/pre-commit"
 
+[tools.pre-commit."platforms.linux-arm64"]
+checksum = "sha256:19d00ba35cbf9c04dc3736cd8bb641e8633f3eddd4cedde71809574ae68a2cd1"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.1/pre-commit-4.5.1.pyz"
+
+[tools.pre-commit."platforms.linux-arm64-musl"]
+checksum = "sha256:19d00ba35cbf9c04dc3736cd8bb641e8633f3eddd4cedde71809574ae68a2cd1"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.1/pre-commit-4.5.1.pyz"
+
+[tools.pre-commit."platforms.linux-x64"]
+checksum = "sha256:19d00ba35cbf9c04dc3736cd8bb641e8633f3eddd4cedde71809574ae68a2cd1"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.1/pre-commit-4.5.1.pyz"
+
+[tools.pre-commit."platforms.linux-x64-musl"]
+checksum = "sha256:19d00ba35cbf9c04dc3736cd8bb641e8633f3eddd4cedde71809574ae68a2cd1"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.1/pre-commit-4.5.1.pyz"
+
+[tools.pre-commit."platforms.macos-arm64"]
+checksum = "sha256:19d00ba35cbf9c04dc3736cd8bb641e8633f3eddd4cedde71809574ae68a2cd1"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.1/pre-commit-4.5.1.pyz"
+
+[tools.pre-commit."platforms.macos-x64"]
+checksum = "sha256:19d00ba35cbf9c04dc3736cd8bb641e8633f3eddd4cedde71809574ae68a2cd1"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.1/pre-commit-4.5.1.pyz"
+
 [[tools.python]]
 version = "3.13.12"
 backend = "core:python"
@@ -15,3 +39,32 @@ backend = "core:python"
 [[tools.uv]]
 version = "0.11.1"
 backend = "aqua:astral-sh/uv"
+
+[tools.uv."platforms.linux-arm64"]
+checksum = "sha256:bd04ffce77ee8d77f39823c13606183581847c2f5dcd704f2ea0f15e376b1a27"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.1/uv-aarch64-unknown-linux-musl.tar.gz"
+
+[tools.uv."platforms.linux-arm64-musl"]
+checksum = "sha256:bd04ffce77ee8d77f39823c13606183581847c2f5dcd704f2ea0f15e376b1a27"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.1/uv-aarch64-unknown-linux-musl.tar.gz"
+
+[tools.uv."platforms.linux-x64"]
+checksum = "sha256:4e949471a95b37088a1ff1a585f69abed4d3cd3f921f50709a46b6ba62986d38"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.1/uv-x86_64-unknown-linux-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools.uv."platforms.linux-x64-musl"]
+checksum = "sha256:4e949471a95b37088a1ff1a585f69abed4d3cd3f921f50709a46b6ba62986d38"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.1/uv-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.uv."platforms.macos-arm64"]
+checksum = "sha256:f7815f739ed5d0e4202e6292acedb8659b9ae7de663d07188d8c6cbd7f96303f"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.1/uv-aarch64-apple-darwin.tar.gz"
+
+[tools.uv."platforms.macos-x64"]
+checksum = "sha256:2103670e8e949605e51926c7b953923ff6f6befbfb55aee928f5e760c9c910f8"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.1/uv-x86_64-apple-darwin.tar.gz"
+
+[tools.uv."platforms.windows-x64"]
+checksum = "sha256:6659250cebbd3bb6ee48bcb21a3f0c6656450d63fb97f0f069bcb532bdb688ed"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.1/uv-x86_64-pc-windows-msvc.zip"


### PR DESCRIPTION
## Summary
- Bump integration version from `0.1.1` to `0.3.0` in `manifest.json` and `const.py`
- Update `mise.lock` with platform-specific checksums for pre-commit and uv tools

## Test plan
- [ ] Verify the integration loads correctly in Home Assistant with the new version
- [ ] Confirm version displays as `0.3.0` in the HACS integration details