### PR TITLE
chore: bump version from 0.3.0 to 0.4.0

### DIFF
--- a/custom_components/mylight_systems/const.py
+++ b/custom_components/mylight_systems/const.py
@@ -10,7 +10,7 @@ LOGGER: Logger = getLogger(__package__)
 NAME = "MyLight Systems"
 DOMAIN = "mylight_systems"
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
-VERSION = "0.3.0"
+VERSION = "0.4.0"
 ATTRIBUTION = "Data provided by https://www.mylight-systems.com/"
 SCAN_INTERVAL_IN_MINUTES = 15
 

--- a/custom_components/mylight_systems/manifest.json
+++ b/custom_components/mylight_systems/manifest.json
@@ -9,5 +9,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/acesyde/hassio_mylight_integration/issues",
-  "version": "0.3.0"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
## Summary
- Bump version from 0.3.0 to 0.4.0 in `const.py` and `manifest.json`

## Test plan
- [ ] Verify integration loads correctly with updated version
- [ ] Confirm version displays correctly in Home Assistant